### PR TITLE
Set XUL browser type attribute to "content"

### DIFF
--- a/runner/chrome/content/app.xul
+++ b/runner/chrome/content/app.xul
@@ -12,6 +12,6 @@
   <xul:browser flex="1"
                id  ="browser"
                src =""
-               type="content-primary"
+               type="content"
   />
 </xul:window>


### PR DESCRIPTION
This prevents github.com showing an error message about framing
when loaded in the browser window.

Fixes #2